### PR TITLE
Spring data support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <name>mongobee</name>
@@ -23,8 +24,8 @@
         <connection>scm:git:git@github.com:mongobee/mongobee.git</connection>
         <developerConnection>scm:git:git@github.com:mongobee/mongobee.git</developerConnection>
         <url>git@github.com:mongobee/mongobee.git</url>
-      <tag>mongobee-0.5</tag>
-  </scm>
+        <tag>mongobee-0.5</tag>
+    </scm>
 
     <developers>
         <developer>
@@ -74,6 +75,12 @@
             <artifactId>jongo</artifactId>
             <version>1.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-mongodb</artifactId>
+            <version>1.6.1.RELEASE</version>
+        </dependency>
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>

--- a/src/main/java/com/github/mongobee/Mongobee.java
+++ b/src/main/java/com/github/mongobee/Mongobee.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.core.env.Environment;
+import org.springframework.data.mongodb.core.MongoTemplate;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -189,6 +190,10 @@ public class Mongobee implements InitializingBean {
             logger.debug("method with Jongo argument");
 
             return changeSetMethod.invoke(changeLogInstance, new Jongo(db));
+        } else if (changeSetMethod.getParameterTypes().length == 1 && changeSetMethod.getParameterTypes()[0].equals(MongoTemplate.class)) {
+            logger.debug("method with MongoTemplate argument");
+
+          return changeSetMethod.invoke(changeLogInstance, new MongoTemplate(db.getMongo(), dbName));
         } else if (changeSetMethod.getParameterTypes().length == 0) {
             logger.debug("method with no params");
 

--- a/src/test/java/com/github/mongobee/MongobeeProfileTest.java
+++ b/src/test/java/com/github/mongobee/MongobeeProfileTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class MongobeeProfileTest {
 
+  public static final int CHANGELOG_COUNT = 10;
   @InjectMocks
   private Mongobee runner = new Mongobee();
 
@@ -146,7 +147,7 @@ public class MongobeeProfileTest {
 
     // then
     int changes = fakeDb.getCollection(CHANGELOG_COLLECTION).find(new BasicDBObject()).count();
-    assertEquals(9, changes);
+    assertEquals(CHANGELOG_COUNT, changes);
   }
 
   @Test
@@ -161,7 +162,7 @@ public class MongobeeProfileTest {
 
     // then
     int changes = fakeDb.getCollection(CHANGELOG_COLLECTION).find(new BasicDBObject()).count();
-    assertEquals(9, changes);
+    assertEquals(CHANGELOG_COUNT, changes);
   }
 
   @Test
@@ -176,7 +177,7 @@ public class MongobeeProfileTest {
 
     // then
     int changes = fakeDb.getCollection(CHANGELOG_COLLECTION).find(new BasicDBObject()).count();
-    assertEquals(9, changes);
+    assertEquals(CHANGELOG_COUNT, changes);
   }
 
 }

--- a/src/test/java/com/github/mongobee/MongobeeTest.java
+++ b/src/test/java/com/github/mongobee/MongobeeTest.java
@@ -66,7 +66,7 @@ public class MongobeeTest {
     runner.execute();
 
     // then
-    verify(dao, times(9)).save(any(ChangeEntry.class)); // 9 changesets saved to dbchangelog
+    verify(dao, times(10)).save(any(ChangeEntry.class)); // 10 changesets saved to dbchangelog
 
       // dbchangelog collection checking
     int change1 = fakeDb.getCollection(CHANGELOG_COLLECTION).find(new BasicDBObject()

--- a/src/test/java/com/github/mongobee/test/changelogs/SpringDataChangelog.java
+++ b/src/test/java/com/github/mongobee/test/changelogs/SpringDataChangelog.java
@@ -1,0 +1,17 @@
+package com.github.mongobee.test.changelogs;
+
+import com.github.mongobee.changeset.ChangeLog;
+import com.github.mongobee.changeset.ChangeSet;
+import org.jongo.Jongo;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+/**
+ * @author abelski
+ */
+@ChangeLog
+public class SpringDataChangelog {
+  @ChangeSet(author = "abelski", id = "spring_test4", order = "04")
+  public void testChangeSet(MongoTemplate mongoTemplate) {
+    System.out.println("invoked  with mongoTemplate=" + mongoTemplate.toString());
+  }
+}


### PR DESCRIPTION
Jongo uses Annotation @ id is different from the Annotated used in Spring data(http://projects.spring.io/spring-data-mongodb/  quite popular lib).

@ org.springframework.data.annotation.Id
@ org.jongo.marshall.jackson.oid.Id

so if you use Spring date in your application you will have to modify entity in order to be able to migrate. The simplest solution of this issue will add support for Spring data to the library.
