### PR TITLE
Mongobee can be made to use pre-configured MongoTemplate and Jongo

### DIFF
--- a/src/main/java/com/github/mongobee/Mongobee.java
+++ b/src/main/java/com/github/mongobee/Mongobee.java
@@ -39,6 +39,9 @@ public class Mongobee implements InitializingBean {
   private Mongo mongo;
   private String dbName;
   private Environment springEnvironment;
+  
+  private MongoTemplate mongoTemplate;
+  private Jongo jongo;
 
   /**
    * <p>Simple constructor with default configuration of host (localhost) and port (27017). Although
@@ -190,12 +193,12 @@ public class Mongobee implements InitializingBean {
         && changeSetMethod.getParameterTypes()[0].equals(Jongo.class)) {
       logger.debug("method with Jongo argument");
 
-      return changeSetMethod.invoke(changeLogInstance, new Jongo(db));
+      return changeSetMethod.invoke(changeLogInstance, jongo != null ? jongo : new Jongo(db));
     } else if (changeSetMethod.getParameterTypes().length == 1
         && changeSetMethod.getParameterTypes()[0].equals(MongoTemplate.class)) {
       logger.debug("method with MongoTemplate argument");
 
-      return changeSetMethod.invoke(changeLogInstance, new MongoTemplate(db.getMongo(), dbName));
+      return changeSetMethod.invoke(changeLogInstance, mongoTemplate != null ? mongoTemplate : new MongoTemplate(db.getMongo(), dbName));
     } else if (changeSetMethod.getParameterTypes().length == 0) {
       logger.debug("method with no params");
 
@@ -276,4 +279,23 @@ public class Mongobee implements InitializingBean {
     this.springEnvironment = environment;
     return this;
   }
+  /**
+   * Sets pre-configured {@link MongoTemplate} instance to use by the Mongobee 
+   * @param mongoTemplate instance of the {@link MongoTemplate}
+   * @return Mongobee object for fluent interface
+   */
+  public Mongobee setMongoTemplate(MongoTemplate mongoTemplate) {
+    this.mongoTemplate = mongoTemplate;
+    return this;
+  }
+  /**
+   * Sets pre-configured {@link MongoTemplate} instance to use by the Mongobee 
+   * @param jongo {@link Jongo} instance  
+   * @return Mongobee object for fluent interface
+   */
+  public Mongobee setJongo(Jongo jongo) {
+    this.jongo = jongo;
+    return this;
+  }
+  
 }

--- a/src/test/java/com/github/mongobee/MongobeeTest.java
+++ b/src/test/java/com/github/mongobee/MongobeeTest.java
@@ -1,5 +1,27 @@
 package com.github.mongobee;
 
+import static com.github.mongobee.changeset.ChangeEntry.CHANGELOG_COLLECTION;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.UnknownHostException;
+import java.util.Collections;
+
+import org.jongo.Jongo;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
 import com.github.fakemongo.Fongo;
 import com.github.mongobee.changeset.ChangeEntry;
 import com.github.mongobee.dao.ChangeEntryDao;
@@ -7,22 +29,11 @@ import com.github.mongobee.exception.MongobeeConfigurationException;
 import com.github.mongobee.exception.MongobeeException;
 import com.github.mongobee.test.changelogs.MongobeeTestResource;
 import com.mongodb.BasicDBObject;
+import com.mongodb.CommandResult;
 import com.mongodb.DB;
+import com.mongodb.DBCollection;
 import com.mongodb.MongoClientURI;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-
-import java.net.UnknownHostException;
-
-import static com.github.mongobee.changeset.ChangeEntry.CHANGELOG_COLLECTION;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
+import com.mongodb.ServerAddress;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MongobeeTest {
@@ -102,4 +113,29 @@ public class MongobeeTest {
     verify(dao, times(0)).save(any(ChangeEntry.class)); // no changesets saved to dbchangelog
   }
 
+  @Test
+  public void shouldUsePreConfiguredMongoTemplate () throws Exception {
+    MongoTemplate mt = mock(MongoTemplate.class);
+    when(mt.getCollectionNames()).thenReturn(Collections.EMPTY_SET);
+    when(dao.isNewChange(any(ChangeEntry.class))).thenReturn(true);
+    runner.setMongoTemplate(mt);
+    runner.afterPropertiesSet();
+    verify(mt).getCollectionNames();
+  }
+  
+  @Test
+  public void shouldUsePreConfiguredJongo () throws Exception {
+    Jongo jongo = mock(Jongo.class);
+    when(jongo.getDatabase()).thenReturn(null);
+    runner.setJongo(jongo);
+    runner.afterPropertiesSet();
+    verify(jongo).getDatabase();
+  }
+  
+  @After
+  public void cleanUp() {
+    runner.setMongoTemplate(null);
+    runner.setJongo(null);
+  }
+  
 }

--- a/src/test/java/com/github/mongobee/test/changelogs/SpringDataChangelog.java
+++ b/src/test/java/com/github/mongobee/test/changelogs/SpringDataChangelog.java
@@ -13,5 +13,6 @@ public class SpringDataChangelog {
   @ChangeSet(author = "abelski", id = "spring_test4", order = "04")
   public void testChangeSet(MongoTemplate mongoTemplate) {
     System.out.println("invoked  with mongoTemplate=" + mongoTemplate.toString());
+    System.out.println("invoked  with mongoTemplate=" + mongoTemplate.getCollectionNames());
   }
 }


### PR DESCRIPTION
Mongobee now can use pre-configured MongoTemplate and Jongo rather than create its own every time it runs a changeset.
This is useful if one has custom converters in the Spring based application for instance. Iit could be made to use MongoTemplate instance with custom converters rather than default ones only.
