### PR TITLE
Update for mongo-java-driver v3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>
-            <version>2.12.2</version>
+            <version>3.2.1</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>com.github.fakemongo</groupId>
             <artifactId>fongo</artifactId>
-            <version>1.5.5</version>
+            <version>2.0.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/com/github/mongobee/MongobeeProfileTest.java
+++ b/src/test/java/com/github/mongobee/MongobeeProfileTest.java
@@ -10,6 +10,8 @@ import com.github.mongobee.test.profiles.dev.ProfiledDevChangeLog;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
 import com.mongodb.MongoClientURI;
+import com.mongodb.client.MongoDatabase;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,7 +34,7 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class MongobeeProfileTest {
 
-  public static final int CHANGELOG_COUNT = 10;
+  public static final int CHANGELOG_COUNT = 12;
   @InjectMocks
   private Mongobee runner = new Mongobee();
 
@@ -40,14 +42,17 @@ public class MongobeeProfileTest {
   private ChangeEntryDao dao;
 
   private DB fakeDb;
+  private MongoDatabase fakeMongoDatabase;
 
   @Before
   public void init() throws Exception {
 
     fakeDb = new Fongo("testServer").getDB("mongobeetest");
+    fakeMongoDatabase = new Fongo("testServer").getDatabase("mongobeetest");
     when(dao.connectMongoDb(any(MongoClientURI.class), anyString()))
       .thenReturn(fakeDb);
     when(dao.getDb()).thenReturn(fakeDb);
+    when(dao.getMongoDatabase()).thenReturn(fakeMongoDatabase);
     when(dao.save(any(ChangeEntry.class))).thenCallRealMethod();
 
     runner.setDbName("mongobeetest");

--- a/src/test/java/com/github/mongobee/dao/ChangeEntryDaoTest.java
+++ b/src/test/java/com/github/mongobee/dao/ChangeEntryDaoTest.java
@@ -6,6 +6,8 @@ import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
 import com.mongodb.DBObject;
 import com.mongodb.Mongo;
+import com.mongodb.MongoClient;
+
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -28,7 +30,7 @@ public class ChangeEntryDaoTest {
   public void shouldCreateChangeIdAuthorIndexIfNotFound() throws MongobeeConfigurationException {
 
     // given
-    Mongo mongo = mock(Mongo.class);
+    MongoClient mongo = mock(MongoClient.class);
     DB db = new Fongo(TEST_SERVER).getDB(DB_NAME);
     when(mongo.getDB(Mockito.anyString())).thenReturn(db);
 
@@ -50,7 +52,7 @@ public class ChangeEntryDaoTest {
   public void shouldNotCreateChangeIdAuthorIndexIfFound() throws MongobeeConfigurationException {
 
     // given
-    Mongo mongo = mock(Mongo.class);
+    MongoClient mongo = mock(MongoClient.class);
     DB db = new Fongo(TEST_SERVER).getDB(DB_NAME);
     when(mongo.getDB(Mockito.anyString())).thenReturn(db);
 
@@ -73,7 +75,7 @@ public class ChangeEntryDaoTest {
   public void shouldRecreateChangeIdAuthorIndexIfFoundNotUnique() throws MongobeeConfigurationException {
 
     // given
-    Mongo mongo = mock(Mongo.class);
+    MongoClient mongo = mock(MongoClient.class);
     DB db = new Fongo(TEST_SERVER).getDB(DB_NAME);
     when(mongo.getDB(Mockito.anyString())).thenReturn(db);
 

--- a/src/test/java/com/github/mongobee/test/changelogs/AnotherMongobeeTestResource.java
+++ b/src/test/java/com/github/mongobee/test/changelogs/AnotherMongobeeTestResource.java
@@ -2,6 +2,8 @@ package com.github.mongobee.test.changelogs;
 
 import com.github.mongobee.changeset.ChangeLog;
 import com.mongodb.DB;
+import com.mongodb.client.MongoDatabase;
+
 import org.jongo.Jongo;
 import com.github.mongobee.changeset.ChangeSet;
 
@@ -35,4 +37,10 @@ public class AnotherMongobeeTestResource {
   public void testChangeSetWithAlways(Jongo jongo){
     System.out.println("invoked B5 with always + jongo=" + jongo.getDatabase());
   }
+
+  @ChangeSet(author = "testuser", id = "Btest6", order = "06")
+  public void testChangeSet6(MongoDatabase mongoDatabase){
+    System.out.println("invoked B6 with db=" + mongoDatabase.toString());
+  }
+  
 }

--- a/src/test/java/com/github/mongobee/test/changelogs/MongobeeTestResource.java
+++ b/src/test/java/com/github/mongobee/test/changelogs/MongobeeTestResource.java
@@ -2,6 +2,8 @@ package com.github.mongobee.test.changelogs;
 
 import com.github.mongobee.changeset.ChangeLog;
 import com.mongodb.DB;
+import com.mongodb.client.MongoDatabase;
+
 import org.jongo.Jongo;
 import com.github.mongobee.changeset.ChangeSet;
 
@@ -36,6 +38,13 @@ public class MongobeeTestResource {
   public void testChangeSet4(Jongo jongo){
 
       System.out.println("invoked 4 with jongo=" + jongo.toString());
+
+  }
+
+  @ChangeSet(author = "testuser", id = "test5", order = "05")
+  public void testChangeSet5(MongoDatabase mongoDatabase){
+
+    System.out.println("invoked 5 with db=" + mongoDatabase.toString());
 
   }
 }

--- a/src/test/java/com/github/mongobee/utils/ChangeServiceTest.java
+++ b/src/test/java/com/github/mongobee/utils/ChangeServiceTest.java
@@ -39,7 +39,7 @@ public class ChangeServiceTest {
     List<Method> foundMethods = service.fetchChangeSets(MongobeeTestResource.class);
     
     // then
-    assertTrue(foundMethods != null && foundMethods.size() == 4);
+    assertTrue(foundMethods != null && foundMethods.size() == 5);
   }
 
   @Test
@@ -58,7 +58,7 @@ public class ChangeServiceTest {
         assertFalse(service.isRunAlwaysChangeSet(foundMethod));
       }
     }
-    assertTrue(foundMethods != null && foundMethods.size() == 5);
+    assertTrue(foundMethods != null && foundMethods.size() == 6);
   }
 
   @Test


### PR DESCRIPTION
Mongo() constructor and getDb() are now deprecated, support is needed for MongoDatabase in order to allow the use of Mongobee in any new project development.

- updated mongo java driver to 3.2.1
- updated Fongo to 2.0.4
- modified tests for changesets that take a MongoDatabase parameter
- added support for changesets that take a MongoDatabase parameter
- removed try block from ChangeEntryDao.connectMongoDb (exception is no
longer thrown as of 3.0)