### PR TITLE
Include ChangeLogClass in ChangeEntry search query

### DIFF
--- a/src/main/java/com/github/mongobee/changeset/ChangeEntry.java
+++ b/src/main/java/com/github/mongobee/changeset/ChangeEntry.java
@@ -8,75 +8,77 @@ import java.util.Date;
 /**
  * Entry in the changes collection log {@link ChangeEntry#CHANGELOG_COLLECTION}
  * Type: entity class.
+ *
  * @author lstolowski
  * @since 27/07/2014
  */
 public class ChangeEntry {
-  public static final String CHANGELOG_COLLECTION = "dbchangelog"; // ! Don't change due to backward compatibility issue
+    public static final String CHANGELOG_COLLECTION = "dbchangelog"; // ! Don't change due to backward compatibility issue
 
-  public static final String KEY_CHANGEID = "changeId";
-  public static final String KEY_AUTHOR = "author";
-  public static final String KEY_TIMESTAMP = "timestamp";
-  public static final String KEY_CHANGELOGCLASS = "changeLogClass";
-  public static final String KEY_CHANGESETMETHOD = "changeSetMethod";
+    public static final String KEY_CHANGEID = "changeId";
+    public static final String KEY_AUTHOR = "author";
+    public static final String KEY_TIMESTAMP = "timestamp";
+    public static final String KEY_CHANGELOGCLASS = "changeLogClass";
+    public static final String KEY_CHANGESETMETHOD = "changeSetMethod";
 
-  private String changeId;
-  private String author;
-  private Date timestamp;
-  private String changeLogClass;
-  private String changeSetMethodName;
+    private String changeId;
+    private String author;
+    private Date timestamp;
+    private String changeLogClass;
+    private String changeSetMethodName;
 
-  public ChangeEntry(String changeId, String author, Date timestamp, String changeLogClass, String changeSetMethodName) {
-    this.changeId = changeId;
-    this.author = author;
-    this.timestamp = new Date(timestamp.getTime());
-    this.changeLogClass = changeLogClass;
-    this.changeSetMethodName = changeSetMethodName;
-  }
+    public ChangeEntry(String changeId, String author, Date timestamp, String changeLogClass, String changeSetMethodName) {
+        this.changeId = changeId;
+        this.author = author;
+        this.timestamp = new Date(timestamp.getTime());
+        this.changeLogClass = changeLogClass;
+        this.changeSetMethodName = changeSetMethodName;
+    }
 
-  public DBObject buildFullDBObject(){
-    BasicDBObject entry = new BasicDBObject();
-    
-    entry.append(KEY_CHANGEID, this.changeId)
-            .append(KEY_AUTHOR, this.author)
-            .append(KEY_TIMESTAMP, this.timestamp)
-            .append(KEY_CHANGELOGCLASS, this.changeLogClass)
-            .append(KEY_CHANGESETMETHOD, this.changeSetMethodName);
-    
-    return entry;
-  }
-  
-  public DBObject buildSearchQueryDBObject(){
-    return new BasicDBObject()
-                  .append(KEY_CHANGEID, this.changeId)
-                  .append(KEY_AUTHOR, this.author);
-  }
+    public DBObject buildFullDBObject() {
+        BasicDBObject entry = new BasicDBObject();
 
-  @Override
-  public String toString() {
-    return "[ChangeSet: id=" + this.changeId +
-            ", author=" + this.author +
-            ", changeLogClass=" + this.changeLogClass +
-            ", changeSetMethod=" + this.changeSetMethodName + "]";
-  }
+        entry.append(KEY_CHANGEID, this.changeId)
+             .append(KEY_AUTHOR, this.author)
+             .append(KEY_TIMESTAMP, this.timestamp)
+             .append(KEY_CHANGELOGCLASS, this.changeLogClass)
+             .append(KEY_CHANGESETMETHOD, this.changeSetMethodName);
 
-  public String getChangeId() {
-    return this.changeId;
-  }
+        return entry;
+    }
 
-  public String getAuthor() {
-    return this.author;
-  }
+    public DBObject buildSearchQueryDBObject() {
+        return new BasicDBObject()
+                .append(KEY_CHANGEID, this.changeId)
+                .append(KEY_AUTHOR, this.author)
+                .append(KEY_CHANGELOGCLASS, this.changeLogClass);
+    }
 
-  public Date getTimestamp() {
-    return this.timestamp;
-  }
+    @Override
+    public String toString() {
+        return "[ChangeSet: id=" + this.changeId +
+                ", author=" + this.author +
+                ", changeLogClass=" + this.changeLogClass +
+                ", changeSetMethod=" + this.changeSetMethodName + "]";
+    }
 
-  public String getChangeLogClass() {
-    return this.changeLogClass;
-  }
+    public String getChangeId() {
+        return this.changeId;
+    }
 
-  public String getChangeSetMethodName() {
-    return this.changeSetMethodName;
-  }
+    public String getAuthor() {
+        return this.author;
+    }
+
+    public Date getTimestamp() {
+        return this.timestamp;
+    }
+
+    public String getChangeLogClass() {
+        return this.changeLogClass;
+    }
+
+    public String getChangeSetMethodName() {
+        return this.changeSetMethodName;
+    }
 }

--- a/src/main/java/com/github/mongobee/dao/ChangeEntryIndexDao.java
+++ b/src/main/java/com/github/mongobee/dao/ChangeEntryIndexDao.java
@@ -1,6 +1,7 @@
 package com.github.mongobee.dao;
 
 import static com.github.mongobee.changeset.ChangeEntry.CHANGELOG_COLLECTION;
+import static com.github.mongobee.changeset.ChangeEntry.KEY_CHANGELOGCLASS;
 
 import com.github.mongobee.changeset.ChangeEntry;
 import com.mongodb.BasicDBObject;
@@ -14,34 +15,36 @@ import com.mongodb.DBObject;
  */
 public class ChangeEntryIndexDao {
 
-  public void createRequiredUniqueIndex(DBCollection collection) {
-    collection.createIndex(new BasicDBObject()
-            .append(ChangeEntry.KEY_CHANGEID, 1)
-            .append(ChangeEntry.KEY_AUTHOR, 1),
-        new BasicDBObject().append("unique", true));
-  }
+    public void createRequiredUniqueIndex(DBCollection collection) {
+        collection.createIndex(new BasicDBObject()
+                                       .append(ChangeEntry.KEY_CHANGEID, 1)
+                                       .append(ChangeEntry.KEY_AUTHOR, 1)
+                                       .append(ChangeEntry.KEY_CHANGELOGCLASS, 1),
 
-  public DBObject findRequiredChangeAndAuthorIndex(DB db) {
-    DBCollection indexes = db.getCollection("system.indexes");
-    DBObject index = indexes.findOne(new BasicDBObject()
-        .append("ns", db.getName() + "." + CHANGELOG_COLLECTION)
-        .append("key", new BasicDBObject().append(ChangeEntry.KEY_CHANGEID, 1).append(ChangeEntry.KEY_AUTHOR, 1))
-    );
-
-    return index;
-  }
-
-  public boolean isUnique(DBObject index) {
-    Object unique = index.get("unique");
-    if (unique != null && unique instanceof Boolean) {
-      return (Boolean) unique;
-    } else {
-      return false;
+                               new BasicDBObject().append("unique", true));
     }
-  }
 
-  public void dropIndex(DBCollection collection, DBObject index) {
-    collection.dropIndex(index.get("name").toString());
-  }
+    public DBObject findRequiredChangeAndAuthorIndex(DB db) {
+        DBCollection indexes = db.getCollection("system.indexes");
+        DBObject index = indexes.findOne(new BasicDBObject()
+                                                 .append("ns", db.getName() + "." + CHANGELOG_COLLECTION)
+                                                 .append("key", new BasicDBObject().append(ChangeEntry.KEY_CHANGEID, 1).append(ChangeEntry.KEY_AUTHOR, 1))
+                                        );
+
+        return index;
+    }
+
+    public boolean isUnique(DBObject index) {
+        Object unique = index.get("unique");
+        if (unique != null && unique instanceof Boolean) {
+            return (Boolean) unique;
+        } else {
+            return false;
+        }
+    }
+
+    public void dropIndex(DBCollection collection, DBObject index) {
+        collection.dropIndex(index.get("name").toString());
+    }
 
 }

--- a/src/test/java/com/github/mongobee/changeset/ChangeEntryTest.java
+++ b/src/test/java/com/github/mongobee/changeset/ChangeEntryTest.java
@@ -1,0 +1,26 @@
+package com.github.mongobee.changeset;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+import org.junit.Test;
+
+import java.util.Date;
+
+import static com.github.mongobee.changeset.ChangeEntry.KEY_AUTHOR;
+import static com.github.mongobee.changeset.ChangeEntry.KEY_CHANGEID;
+import static com.github.mongobee.changeset.ChangeEntry.KEY_CHANGELOGCLASS;
+import static org.junit.Assert.*;
+
+public class ChangeEntryTest {
+    @Test
+    public void shouldReturnTheCorrectlyPopulatedSearchObject() {
+        ChangeEntry changeEntry = new ChangeEntry("changedId", "author", new Date(), "changeLogClass", "changeSetMethod");
+        BasicDBObject expectedSearchQuery = new BasicDBObject().append(KEY_CHANGEID, changeEntry.getChangeId())
+                                                               .append(KEY_AUTHOR, changeEntry.getAuthor())
+                                                               .append(KEY_CHANGELOGCLASS, changeEntry.getChangeLogClass());
+
+        DBObject searchQuery = changeEntry.buildSearchQueryDBObject();
+
+        assertEquals(searchQuery, expectedSearchQuery);
+    }
+}

--- a/src/test/java/com/github/mongobee/dao/ChangeEntryIndexDaoTest.java
+++ b/src/test/java/com/github/mongobee/dao/ChangeEntryIndexDaoTest.java
@@ -24,61 +24,62 @@ import com.mongodb.Mongo;
  * @since 10.12.14
  */
 public class ChangeEntryIndexDaoTest {
-  private static final String TEST_SERVER = "testServer";
-  private static final String DB_NAME = "mongobeetest";
-  private static final String CHANGEID_AUTHOR_INDEX_NAME = "changeId_1_author_1";
+    private static final String TEST_SERVER = "testServer";
+    private static final String DB_NAME = "mongobeetest";
+    private static final String CHANGEID_AUTHOR_CHANGELOGCLASS_INDEX_NAME = "changeId_1_author_1_changeLogClass_1";
 
-  private ChangeEntryIndexDao dao = new ChangeEntryIndexDao();
+    private ChangeEntryIndexDao dao = new ChangeEntryIndexDao();
 
-  @Test
-  public void shouldCreateRequiredUniqueIndex() {
-    // given
-    Mongo mongo = mock(Mongo.class);
-    DB db = new Fongo(TEST_SERVER).getDB(DB_NAME);
-    when(mongo.getDB(Mockito.anyString())).thenReturn(db);
+    @Test
+    public void shouldCreateRequiredUniqueIndex() {
+        // given
+        Mongo mongo = mock(Mongo.class);
+        DB db = new Fongo(TEST_SERVER).getDB(DB_NAME);
+        when(mongo.getDB(Mockito.anyString())).thenReturn(db);
 
-    // when
-    dao.createRequiredUniqueIndex(db.getCollection(CHANGELOG_COLLECTION));
+        // when
+        dao.createRequiredUniqueIndex(db.getCollection(CHANGELOG_COLLECTION));
 
-    // then
-    DBObject createdIndex = findIndex(db, CHANGEID_AUTHOR_INDEX_NAME);
-    assertNotNull(createdIndex);
-    assertTrue(dao.isUnique(createdIndex));
-  }
-
-  @Test
-  public void shouldDropWrongIndex() {
-    // init
-    Mongo mongo = mock(Mongo.class);
-    DB db = new Fongo(TEST_SERVER).getDB(DB_NAME);
-    when(mongo.getDB(Mockito.anyString())).thenReturn(db);
-
-    DBCollection collection = db.getCollection(CHANGELOG_COLLECTION);
-    collection.createIndex(new BasicDBObject()
-        .append(ChangeEntry.KEY_CHANGEID, 1)
-        .append(ChangeEntry.KEY_AUTHOR, 1));
-    DBObject index = new BasicDBObject("name", CHANGEID_AUTHOR_INDEX_NAME);
-
-    // given
-    DBObject createdIndex = findIndex(db, CHANGEID_AUTHOR_INDEX_NAME);
-    assertNotNull(createdIndex);
-    assertFalse(dao.isUnique(createdIndex));
-
-    // when
-    dao.dropIndex(db.getCollection(CHANGELOG_COLLECTION), index);
-
-    // then
-    assertNull(findIndex(db, CHANGEID_AUTHOR_INDEX_NAME));
-  }
-
-  private DBObject findIndex(DB db, String indexName) {
-    for (DBObject index : db.getCollection(CHANGELOG_COLLECTION).getIndexInfo()) {
-      String name = (String) index.get("name");
-      if (indexName.equals(name)) {
-        return index;
-      }
+        // then
+        DBObject createdIndex = findIndex(db, CHANGEID_AUTHOR_CHANGELOGCLASS_INDEX_NAME);
+        assertNotNull(createdIndex);
+        assertTrue(dao.isUnique(createdIndex));
     }
-    return null;
-  }
+
+    @Test
+    public void shouldDropWrongIndex() {
+        // init
+        Mongo mongo = mock(Mongo.class);
+        DB db = new Fongo(TEST_SERVER).getDB(DB_NAME);
+        when(mongo.getDB(Mockito.anyString())).thenReturn(db);
+
+        DBCollection collection = db.getCollection(CHANGELOG_COLLECTION);
+        collection.createIndex(new BasicDBObject()
+                                       .append(ChangeEntry.KEY_CHANGEID, 1)
+                                       .append(ChangeEntry.KEY_AUTHOR, 1)
+                                       .append(ChangeEntry.KEY_CHANGELOGCLASS, 1));
+        DBObject index = new BasicDBObject("name", CHANGEID_AUTHOR_CHANGELOGCLASS_INDEX_NAME);
+
+        // given
+        DBObject createdIndex = findIndex(db, CHANGEID_AUTHOR_CHANGELOGCLASS_INDEX_NAME);
+        assertNotNull(createdIndex);
+        assertFalse(dao.isUnique(createdIndex));
+
+        // when
+        dao.dropIndex(db.getCollection(CHANGELOG_COLLECTION), index);
+
+        // then
+        assertNull(findIndex(db, CHANGEID_AUTHOR_CHANGELOGCLASS_INDEX_NAME));
+    }
+
+    private DBObject findIndex(DB db, String indexName) {
+        for (DBObject index : db.getCollection(CHANGELOG_COLLECTION).getIndexInfo()) {
+            String name = (String) index.get("name");
+            if (indexName.equals(name)) {
+                return index;
+            }
+        }
+        return null;
+    }
 
 }


### PR DESCRIPTION
In order to support splitting change log classes up (i.e. one change log class per collection) it is useful to include the change log class name in both the ChangeEntry search query and the in the unique index on dbchangelog.

This change adds the required functionality