### PR TITLE
Remove redundant NPE in `verifyDbConnection()`.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,10 @@
             <id>lstolowski</id>
             <name>lstolowski</name>
         </developer>
+        <developer>
+            <id>vbeskrovnov</id>
+            <name>vbeskrovnov</name>
+        </developer>
     </developers>
 
     <distributionManagement>

--- a/src/main/java/com/github/mongobee/Mongobee.java
+++ b/src/main/java/com/github/mongobee/Mongobee.java
@@ -254,10 +254,13 @@ public class Mongobee implements InitializingBean {
 
   /**
    * @return true if an execution is in progress, in any process.
-   * @throws MongobeeConnectionException exception
    */
-  public boolean isExecutionInProgress() throws MongobeeConnectionException {
-    return dao.isProccessLockHeld();
+  public boolean isExecutionInProgress() {
+    try {
+      return dao.isProccessLockHeld();
+    } catch (MongobeeConnectionException e) {
+      return false;
+    }
   }
 
   /**

--- a/src/main/java/com/github/mongobee/dao/ChangeEntryDao.java
+++ b/src/main/java/com/github/mongobee/dao/ChangeEntryDao.java
@@ -112,8 +112,7 @@ public class ChangeEntryDao {
 
   private void verifyDbConnection() throws MongobeeConnectionException {
     if (getMongoDatabase() == null) {
-      throw new MongobeeConnectionException("Database is not connected. Mongobee has thrown an unexpected error",
-          new NullPointerException());
+      throw new MongobeeConnectionException("Database is not connected. Mongobee has thrown an unexpected error");
     }
   }
 

--- a/src/main/java/com/github/mongobee/exception/MongobeeConnectionException.java
+++ b/src/main/java/com/github/mongobee/exception/MongobeeConnectionException.java
@@ -7,6 +7,11 @@ package com.github.mongobee.exception;
  * @since 27/07/2014
  */
 public class MongobeeConnectionException extends MongobeeException {
+
+  public MongobeeConnectionException(String message) {
+    super(message);
+  }
+
   public MongobeeConnectionException(String message, Exception baseException) {
     super(message, baseException);
   }


### PR DESCRIPTION
This PR resolves #67. It consists of refactoring `MongobeeConnectionException` to support constructor with error message only.