### PR TITLE
Removed deprecated system.indexes call

### DIFF
--- a/src/main/java/com/github/mongobee/dao/ChangeEntryDao.java
+++ b/src/main/java/com/github/mongobee/dao/ChangeEntryDao.java
@@ -1,13 +1,5 @@
 package com.github.mongobee.dao;
 
-import static org.springframework.util.StringUtils.hasText;
-
-import java.util.Date;
-
-import org.bson.Document;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.github.mongobee.changeset.ChangeEntry;
 import com.github.mongobee.exception.MongobeeConfigurationException;
 import com.github.mongobee.exception.MongobeeConnectionException;
@@ -17,6 +9,13 @@ import com.mongodb.MongoClient;
 import com.mongodb.MongoClientURI;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
+import org.bson.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Date;
+
+import static org.springframework.util.StringUtils.hasText;
 
 /**
  * @author lstolowski
@@ -153,7 +152,7 @@ public class ChangeEntryDao {
   }
 
   private void ensureChangeLogCollectionIndex(MongoCollection<Document> collection) {
-    Document index = indexDao.findRequiredChangeAndAuthorIndex(mongoDatabase);
+    Document index = indexDao.findRequiredChangeAndAuthorIndex(collection);
     if (index == null) {
       indexDao.createRequiredUniqueIndex(collection);
       logger.debug("Index in collection " + changelogCollectionName + " was created");

--- a/src/main/java/com/github/mongobee/dao/ChangeEntryIndexDao.java
+++ b/src/main/java/com/github/mongobee/dao/ChangeEntryIndexDao.java
@@ -1,11 +1,9 @@
 package com.github.mongobee.dao;
 
-import org.bson.Document;
-
 import com.github.mongobee.changeset.ChangeEntry;
 import com.mongodb.client.MongoCollection;
-import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.IndexOptions;
+import org.bson.Document;
 
 /**
  * @author lstolowski
@@ -27,14 +25,15 @@ public class ChangeEntryIndexDao {
     );
   }
 
-  public Document findRequiredChangeAndAuthorIndex(MongoDatabase db) {
-    MongoCollection<Document> indexes = db.getCollection("system.indexes");
-    Document index = indexes.find(new Document()
-        .append("ns", db.getName() + "." + changelogCollectionName)
-        .append("key", new Document().append(ChangeEntry.KEY_CHANGEID, 1).append(ChangeEntry.KEY_AUTHOR, 1))
-    ).first();
+  public Document findRequiredChangeAndAuthorIndex(MongoCollection<Document> collection) {
+    for (Document document: collection.listIndexes()) {
+      Document indexKeys = ((Document) document.get("key"));
+      if (indexKeys != null && (indexKeys.get(ChangeEntry.KEY_CHANGEID) != null && indexKeys.get(ChangeEntry.KEY_AUTHOR) != null)) {
+        return document;
+      }
+    }
 
-    return index;
+    return null;
   }
 
   public boolean isUnique(Document index) {

--- a/src/test/java/com/github/mongobee/dao/ChangeEntryDaoTest.java
+++ b/src/test/java/com/github/mongobee/dao/ChangeEntryDaoTest.java
@@ -1,5 +1,14 @@
 package com.github.mongobee.dao;
 
+import com.github.fakemongo.Fongo;
+import com.github.mongobee.exception.MongobeeConfigurationException;
+import com.github.mongobee.exception.MongobeeLockException;
+import com.mongodb.FongoMongoCollection;
+import com.mongodb.MongoClient;
+import com.mongodb.client.MongoDatabase;
+import org.bson.Document;
+import org.junit.Test;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
@@ -8,16 +17,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import org.bson.Document;
-import org.junit.Test;
-
-import com.github.fakemongo.Fongo;
-import com.github.mongobee.exception.MongobeeConfigurationException;
-import com.github.mongobee.exception.MongobeeLockException;
-import com.mongodb.FongoMongoCollection;
-import com.mongodb.MongoClient;
-import com.mongodb.client.MongoDatabase;
 
 /**
  * @author lstolowski
@@ -46,7 +45,7 @@ public class ChangeEntryDaoTest {
     when(mongoClient.getDatabase(anyString())).thenReturn(db);
 
     ChangeEntryIndexDao indexDaoMock = mock(ChangeEntryIndexDao.class);
-    when(indexDaoMock.findRequiredChangeAndAuthorIndex(db)).thenReturn(null);
+    when(indexDaoMock.findRequiredChangeAndAuthorIndex(db.getCollection(CHANGELOG_COLLECTION_NAME))).thenReturn(null);
     dao.setIndexDao(indexDaoMock);
 
     // when
@@ -69,7 +68,7 @@ public class ChangeEntryDaoTest {
     ChangeEntryDao dao = new ChangeEntryDao(CHANGELOG_COLLECTION_NAME, LOCK_COLLECTION_NAME, WAIT_FOR_LOCK,
         CHANGE_LOG_LOCK_WAIT_TIME, CHANGE_LOG_LOCK_POLL_RATE, THROW_EXCEPTION_IF_CANNOT_OBTAIN_LOCK);
     ChangeEntryIndexDao indexDaoMock = mock(ChangeEntryIndexDao.class);
-    when(indexDaoMock.findRequiredChangeAndAuthorIndex(db)).thenReturn(new Document());
+    when(indexDaoMock.findRequiredChangeAndAuthorIndex(db.getCollection(CHANGELOG_COLLECTION_NAME))).thenReturn(new Document());
     when(indexDaoMock.isUnique(any(Document.class))).thenReturn(true);
     dao.setIndexDao(indexDaoMock);
 
@@ -93,7 +92,7 @@ public class ChangeEntryDaoTest {
     ChangeEntryDao dao = new ChangeEntryDao(CHANGELOG_COLLECTION_NAME, LOCK_COLLECTION_NAME, WAIT_FOR_LOCK,
         CHANGE_LOG_LOCK_WAIT_TIME, CHANGE_LOG_LOCK_POLL_RATE, THROW_EXCEPTION_IF_CANNOT_OBTAIN_LOCK);
     ChangeEntryIndexDao indexDaoMock = mock(ChangeEntryIndexDao.class);
-    when(indexDaoMock.findRequiredChangeAndAuthorIndex(db)).thenReturn(new Document());
+    when(indexDaoMock.findRequiredChangeAndAuthorIndex(db.getCollection(anyString()))).thenReturn(new Document());
     when(indexDaoMock.isUnique(any(Document.class))).thenReturn(false);
     dao.setIndexDao(indexDaoMock);
 


### PR DESCRIPTION
**Problem**

Direct call to `system.indexes` is deprecated and some users who are using MongoDb Atlas receive errors like the following one:
```
Error creating bean with name 'mongobee' defined in class path resource [DatabaseConfiguration.class]: Invocation of init method failed; nested exception is com.mongodb.MongoQueryException: Query failed with error code 8000 and error message 'user is not allowed to do action [find] on [test.system.indexes]' on server ********-shard-00-01-mfwhq.mongodb.net:27017
```

Multiple users who are using MongoBee library are affected, see:
[MongoDB Atlas: user is not allowed to do action find on system.indexes
](https://stackoverflow.com/q/49958635/1889928) [Reading of DBname.system.indexes failed on Atlas cluster by mongobee after getting connected
](https://stackoverflow.com/q/49974594/1889928)

Here is an answer from MongoDB representative:

> the listIndexes command should be used in MongoDB 3.0+ (which is the same command called by the db.collection.getIndexes shell helper). Direct access to the system.indexes collection is a carryover from the legacy MMAPv1 implementation: the introduction of the storage engine API in MongoDB 3.0 added a supported command interface.

**Solution**

Instead of direct call to `system.indexes` the code uses `listIndexes` method which is compatible with MongoDB Atlas.