### PR TITLE
Allow ChangeLogs to be instantiated outside MongoBee and passed in

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,18 @@ public Mongobee mongobee(Environment environment) {
 }
 ```
 
+### External change log object creation (option)
+MongoBee allows the developer or another service to handle change log object creation if desired. This is useful in instances where the developer wants to inject other beans or properties into the change log objects.
+**NOTE:** When using this method, all change log objects must be instantiated externally. Mongobee will not scan for other change log classes.
+
+```java
+public Mongobee mongobee(List<Object> preInstantiatedChangeLogs) {
+  Mongobee runner = new Mongobee(uri);
+  runner.setChangeLogObjectList(preInstantiatedChangeLogs);
+  //... etc
+}
+```
+
 ## Known issues
 
 ##### Mongo java driver conflicts

--- a/README.md
+++ b/README.md
@@ -211,7 +211,8 @@ public Mongobee mongobee(Environment environment) {
 ```
 
 ### External change log object creation (option)
-MongoBee allows the developer or another service to handle change log object creation if desired. This is useful in instances where the developer wants to inject other beans or properties into the change log objects.
+MongoBee allows the developer or another service to handle change log object creation if desired. This is useful in instances where the developer wants more control over the change log objects (like in order to populate a change log object with other dependencies).
+
 **NOTE:** When using this method, all change log objects must be instantiated externally. Mongobee will not scan for other change log classes.
 
 ```java

--- a/src/main/java/com/github/mongobee/Mongobee.java
+++ b/src/main/java/com/github/mongobee/Mongobee.java
@@ -298,12 +298,14 @@ public class Mongobee implements InitializingBean {
     return this;
   }
   
-  /**
-   * List of changeLog objects for when constructing your changeLogObjects outside of MongoBee
-   * 
-   * @param changeLogObjectList List of changeLogObjects which will be run.
-   * @return Mongobee object for fluent interface
-   */
+    /**
+     * List of change log objects for when constructing your changeLogObjects outside of MongoBee.
+     * Setting the parameter of this method to anything other than null will cause Mongobee to
+     * skip/ignore the change log scan package.
+     * 
+     * @param changeLogObjectList List of changeLogObjects which will be run.
+     * @return Mongobee object for fluent interface
+     */
   public Mongobee setChangeLogObjectList(List<Object> changeLogObjectList) {
     this.changeLogObjectList = changeLogObjectList;
     return this;

--- a/src/main/java/com/github/mongobee/utils/PackageScannedChangeService.java
+++ b/src/main/java/com/github/mongobee/utils/PackageScannedChangeService.java
@@ -1,0 +1,59 @@
+package com.github.mongobee.utils;
+
+import com.github.mongobee.changeset.ChangeLog;
+import com.github.mongobee.exception.MongobeeException;
+import org.reflections.Reflections;
+import org.springframework.core.env.Environment;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+
+/**
+ * Class to deal with changelogs that are scanned from a package.
+ * 
+ * @author christopher.ogrady
+ *
+ */
+public class PackageScannedChangeService extends ChangeService {
+  private final String changeLogsBasePackage;
+    
+  public PackageScannedChangeService(String changeLogsBasePackage, Environment environment) {
+    super(environment);
+    this.changeLogsBasePackage = changeLogsBasePackage;
+  }
+
+  public PackageScannedChangeService(String changeLogsBasePackage) {
+    this(changeLogsBasePackage, null);
+  }
+  
+  public List<Object> fetchChangeLogs() throws MongobeeException{
+    Reflections reflections = new Reflections(changeLogsBasePackage);
+    Set<Class<?>> changeLogs = reflections.getTypesAnnotatedWith(ChangeLog.class); // TODO remove dependency, do own method
+    List<Class<?>> filteredChangeLogs = (List<Class<?>>) filterByActiveProfiles(changeLogs);
+
+    Collections.sort(filteredChangeLogs, new ChangeLogComparator());
+    List<Object> changeLogInstances = new ArrayList<>();
+    try {
+      for(Class<?> changelogClass : filteredChangeLogs) {
+        changeLogInstances.add(changelogClass.getConstructor().newInstance());
+      }
+    } catch (InstantiationException e) {
+        throw new MongobeeException(e.getMessage(), e);
+    } catch (IllegalAccessException e) {
+        throw new MongobeeException(e.getMessage(), e);
+    } catch (IllegalArgumentException e) {
+        throw new MongobeeException(e.getMessage(), e);
+    } catch (InvocationTargetException e) {
+        throw new MongobeeException(e.getMessage(), e);
+    } catch (NoSuchMethodException e) {
+        throw new MongobeeException(e.getMessage(), e);
+    } catch (SecurityException e) {
+        throw new MongobeeException(e.getMessage(), e);
+    }
+    return changeLogInstances;
+  }
+}

--- a/src/main/java/com/github/mongobee/utils/PreInstantiatedChangeService.java
+++ b/src/main/java/com/github/mongobee/utils/PreInstantiatedChangeService.java
@@ -1,0 +1,27 @@
+package com.github.mongobee.utils;
+
+import com.github.mongobee.exception.MongobeeException;
+import org.springframework.core.env.Environment;
+
+import java.util.List;
+
+/**
+ * Class meant to deal with ChangeLog classes that have already been initiated.
+ * 
+ * @author christopher.ogrady
+ *
+ */
+public class PreInstantiatedChangeService extends ChangeService {
+    
+  private List<Object> preInstantiatedChangeLogs;
+    
+  public PreInstantiatedChangeService(List<Object> preInstantiatedChangeLogs, Environment environment) {
+    super(environment);
+    this.preInstantiatedChangeLogs = preInstantiatedChangeLogs;
+  }
+
+  @Override
+  public List<Object> fetchChangeLogs() throws MongobeeException {
+    return this.preInstantiatedChangeLogs;
+  }
+}

--- a/src/test/java/com/github/mongobee/utils/PackageScannedChangeServiceTest.java
+++ b/src/test/java/com/github/mongobee/utils/PackageScannedChangeServiceTest.java
@@ -2,6 +2,7 @@ package com.github.mongobee.utils;
 
 import com.github.mongobee.changeset.ChangeEntry;
 import com.github.mongobee.exception.MongobeeChangeSetException;
+import com.github.mongobee.exception.MongobeeException;
 import com.github.mongobee.test.changelogs.*;
 import junit.framework.Assert;
 import org.junit.Test;
@@ -16,24 +17,24 @@ import static junit.framework.Assert.assertTrue;
  * @author lstolowski
  * @since 27/07/2014
  */
-public class ChangeServiceTest {
+public class PackageScannedChangeServiceTest {
 
   @Test
-  public void shouldFindChangeLogClasses(){
+  public void shouldFindChangeLogObjects() throws MongobeeException{
     // given
     String scanPackage = MongobeeTestResource.class.getPackage().getName();
-    ChangeService service = new ChangeService(scanPackage);
+    ChangeService service = new PackageScannedChangeService(scanPackage);
     // when
-    List<Class<?>> foundClasses = service.fetchChangeLogs();
+    List<Object> foundObjects = service.fetchChangeLogs();
     // then
-    assertTrue(foundClasses != null && foundClasses.size() > 0);
+    assertTrue(foundObjects != null && foundObjects.size() > 0);
   }
   
   @Test
   public void shouldFindChangeSetMethods() throws MongobeeChangeSetException {
     // given
     String scanPackage = MongobeeTestResource.class.getPackage().getName();
-    ChangeService service = new ChangeService(scanPackage);
+    ChangeService service = new PackageScannedChangeService(scanPackage);
 
     // when
     List<Method> foundMethods = service.fetchChangeSets(MongobeeTestResource.class);
@@ -46,7 +47,7 @@ public class ChangeServiceTest {
   public void shouldFindAnotherChangeSetMethods() throws MongobeeChangeSetException {
     // given
     String scanPackage = MongobeeTestResource.class.getPackage().getName();
-    ChangeService service = new ChangeService(scanPackage);
+    ChangeService service = new PackageScannedChangeService(scanPackage);
 
     // when
     List<Method> foundMethods = service.fetchChangeSets(AnotherMongobeeTestResource.class);
@@ -60,7 +61,7 @@ public class ChangeServiceTest {
   public void shouldFindIsRunAlwaysMethod() throws MongobeeChangeSetException {
     // given
     String scanPackage = MongobeeTestResource.class.getPackage().getName();
-    ChangeService service = new ChangeService(scanPackage);
+    ChangeService service = new PackageScannedChangeService(scanPackage);
 
     // when
     List<Method> foundMethods = service.fetchChangeSets(AnotherMongobeeTestResource.class);
@@ -79,7 +80,7 @@ public class ChangeServiceTest {
     
     // given
     String scanPackage = MongobeeTestResource.class.getPackage().getName();
-    ChangeService service = new ChangeService(scanPackage);
+    ChangeService service = new PackageScannedChangeService(scanPackage);
     List<Method> foundMethods = service.fetchChangeSets(MongobeeTestResource.class);
 
     for (Method foundMethod : foundMethods) {
@@ -99,7 +100,7 @@ public class ChangeServiceTest {
   @Test(expected = MongobeeChangeSetException.class)
   public void shouldFailOnDuplicatedChangeSets() throws MongobeeChangeSetException {
     String scanPackage = ChangeLogWithDuplicate.class.getPackage().getName();
-    ChangeService service = new ChangeService(scanPackage);
+    ChangeService service = new PackageScannedChangeService(scanPackage);
     service.fetchChangeSets(ChangeLogWithDuplicate.class);
   }
 

--- a/src/test/java/com/github/mongobee/utils/PreInstantiatedChangeServiceTest.java
+++ b/src/test/java/com/github/mongobee/utils/PreInstantiatedChangeServiceTest.java
@@ -1,0 +1,30 @@
+package com.github.mongobee.utils;
+
+import com.github.mongobee.exception.MongobeeException;
+import com.github.mongobee.test.changelogs.*;
+import com.google.common.collect.Lists;
+import org.junit.Test;
+
+import java.util.List;
+
+import static junit.framework.Assert.assertTrue;
+
+/**
+ * @author christopher.ogrady
+ * @since 2018/06/12
+ */
+public class PreInstantiatedChangeServiceTest {
+
+  @Test
+  public void shouldFindChangeLogObjects() throws MongobeeException{
+    // given
+    List<Object> instantiatedChangeLogs = Lists.newArrayList(new AnotherMongobeeTestResource(), new EnvironmentDependentTestResource());
+    ChangeService service = new PreInstantiatedChangeService(instantiatedChangeLogs, null);
+    // when
+    List<Object> foundObjects = service.fetchChangeLogs();
+    // then
+    
+    assertTrue(instantiatedChangeLogs.equals(foundObjects));
+  }
+
+}


### PR DESCRIPTION
This is motivated by the desire to allow use with a wider set of DI frameworks which could instantiate change log objects and pass them to MongoBee.

This allows change allows a developer to give MongoBee a predefinied list of change log objects which it will execute on, allowing the setup of change log objects using DI through Guice, Spring, or any other method.

This makes ChangeService an abstract class with implementations of PackageScannedChangeService (current behavior) and PreInstantiatedChangeService. The latter is used when Mongobee is given a list of pre-instantiated change log objects to use before the execute method is called.

This potentially breaks any callers that instantiate ChangeService directly, but ChangeService is never mentioned in current documentation nor used for Mongobee setup, so risk is small.