### PR TITLE
Custom change log loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,34 @@ public Mongobee mongobee(Environment environment) {
 }
 ```
 
+### Custom ChangeLogLoader
+
+The ChangeLogLoader controls how change log classes and methods are filtered and instantiated. By default Mongobee runs with a SpringProfileChangeLogLoader, which filters by using spring profiles pulled from the environment described above. The caller can customize these things by declaring a custom class that extends ChangeLogLoader and passing it into Mongobee.
+
+Example ChangeLogLoader using Guice for injection.
+```java
+public class GuiceChangeLogLoader extends ChangeLogLoader {
+	private Injector injector;
+	public GuiceChangeLogLoader (String changeLogBasePackage, Injector injector) {
+		super(changeLogBasePackage);
+		this.injector = injector;
+	}
+	
+	@Override
+	public Object fetchChangeLogInstance(Class<?> changeLogClass) throws MongobeeException {
+		return injector.getInstance(changeLogClass);
+	}
+}
+```
+```java
+public Mongobee mongobee(String basePackage, Injector) {
+  Mongobee runner = new Mongobee(uri);
+  runner.setChangeLogLoader(new GuiceChangeLogLoader(basePackage, injector));
+  //... etc
+}
+
+```
+
 ## Known issues
 
 ##### Mongo java driver conflicts

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ public class GuiceChangeLogLoader extends ChangeLogLoader {
 }
 ```
 ```java
-public Mongobee mongobee(String basePackage, Injector) {
+public Mongobee mongobee(String basePackage, Injector injector) {
   Mongobee runner = new Mongobee(uri);
   runner.setChangeLogLoader(new GuiceChangeLogLoader(basePackage, injector));
   //... etc

--- a/src/main/java/com/github/mongobee/utils/ChangeLogLoader.java
+++ b/src/main/java/com/github/mongobee/utils/ChangeLogLoader.java
@@ -1,0 +1,130 @@
+package com.github.mongobee.utils;
+
+import com.github.mongobee.changeset.ChangeLog;
+import com.github.mongobee.changeset.ChangeSet;
+import com.github.mongobee.exception.MongobeeChangeSetException;
+import com.github.mongobee.exception.MongobeeException;
+import org.reflections.Reflections;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+
+/**
+ * Class for loading change logs and change sets
+ * 
+ * @author christopher.ogrady
+ *
+ */
+public class ChangeLogLoader {
+
+  private final String changeLogsBasePackage;
+
+  /**
+   * Creates a ChangeLogLoader which searches the provided base package for
+   * change log classes
+   * 
+   * @param changeLogsBasePackage
+   */
+  public ChangeLogLoader(String changeLogsBasePackage) {
+    this.changeLogsBasePackage = changeLogsBasePackage;
+  }
+
+  /**
+   * Fetches classes having the ChangeLog annotation from the base package.
+   * Filters using the filterChangeLogClasses method. Then sorts and returns the
+   * results.
+   * 
+   * @return List of change log classes
+   */
+  List<Class<?>> fetchChangeLogClasses() {
+    Reflections reflections = new Reflections(changeLogsBasePackage);
+    Set<Class<?>> changeLogSet = reflections.getTypesAnnotatedWith(ChangeLog.class);
+    List<Class<?>> filteredChangeLogClassList = filterChangeLogClasses(changeLogSet);
+    Collections.sort(filteredChangeLogClassList, new ChangeLogComparator());
+
+    return filteredChangeLogClassList;
+  }
+  
+  /**
+   * Returns a list of filtered change log classes. On the ChangeLogLoader base
+   * class this is a no-op.
+   * 
+   * @param changeLogClassSet
+   *          {@link Set} of change log classes to be filtered
+   * @return {@link List} of filtered change log classes
+   */
+  public List<Class<?>> filterChangeLogClasses(Set<Class<?>> changeLogClassSet) {
+    return new ArrayList<>(changeLogClassSet);
+  }
+
+  /**
+   * Fetches or instantiates an instance of the provided change log class
+   * 
+   * @param changeLogClass
+   * @return
+   * @throws MongobeeException
+   */
+  public Object fetchChangeLogInstance(Class<?> changeLogClass) throws MongobeeException {
+    try {
+      return changeLogClass.getConstructor().newInstance();
+    } catch (InvocationTargetException e) {
+      throw new MongobeeException(e.getTargetException().getMessage(), e);
+    } catch (InstantiationException | IllegalAccessException | IllegalArgumentException | NoSuchMethodException
+        | SecurityException e) {
+      throw new MongobeeException(e.getMessage(), e);
+    }
+  }
+  
+  /**
+   * Fetches methods having the ChangeSet annotation from the provided class.
+   * Filters using the filterChangeSetMethods method. Then sorts and returns the
+   * results.
+   * 
+   * @param type
+   *          {@link Class} of the change log for which change sets are being
+   *          fetched
+   * @return List of change set methods
+   */
+  List<Method> fetchChangeSets(final Class<?> type) throws MongobeeChangeSetException {
+    final List<Method> changeSets = filterChangeSetAnnotation(asList(type.getDeclaredMethods()));
+    final List<Method> filteredChangeSets = filterChangeSetMethods(changeSets);
+    Collections.sort(filteredChangeSets, new ChangeSetComparator());
+    return filteredChangeSets;
+  }
+
+  /**
+   * Returns a list of filtered change set methods. On the ChangeLogLoader base
+   * class this is a no-op.
+   * 
+   * @param methods
+   *          {@link Set} of change set methods to be filtered
+   * @return {@link List} of filtered change set methods
+   */
+  public List<Method> filterChangeSetMethods(List<Method> methods) {
+    return methods;
+  }
+
+  private List<Method> filterChangeSetAnnotation(List<Method> allMethods) throws MongobeeChangeSetException {
+    final Set<String> changeSetIds = new HashSet<>();
+    final List<Method> changesetMethods = new ArrayList<>();
+    for (final Method method : allMethods) {
+      if (method.isAnnotationPresent(ChangeSet.class)) {
+        String id = method.getAnnotation(ChangeSet.class).id();
+        if (changeSetIds.contains(id)) {
+          throw new MongobeeChangeSetException(String.format("Duplicated changeset id found: '%s'", id));
+        }
+        changeSetIds.add(id);
+        changesetMethods.add(method);
+      }
+    }
+    return changesetMethods;
+  }
+  
+}

--- a/src/main/java/com/github/mongobee/utils/ChangeService.java
+++ b/src/main/java/com/github/mongobee/utils/ChangeService.java
@@ -1,24 +1,14 @@
 package com.github.mongobee.utils;
 
 import com.github.mongobee.changeset.ChangeEntry;
-import com.github.mongobee.changeset.ChangeLog;
 import com.github.mongobee.changeset.ChangeSet;
 import com.github.mongobee.exception.MongobeeChangeSetException;
-import org.reflections.Reflections;
-import org.springframework.context.annotation.Profile;
+import com.github.mongobee.exception.MongobeeException;
 import org.springframework.core.env.Environment;
 
-import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-
-import static java.util.Arrays.asList;
 
 /**
  * Utilities to deal with reflections and annotations
@@ -27,42 +17,44 @@ import static java.util.Arrays.asList;
  * @since 27/07/2014
  */
 public class ChangeService {
-  private static final String DEFAULT_PROFILE = "default";
 
-  private final String changeLogsBasePackage;
-  private final List<String> activeProfiles;
+  private final ChangeLogLoader changeLogLoader;
 
+  /**
+   * Constructs a ChangeService which uses the parameters passed in.
+   * 
+   * @param changeLogsBasePackage
+   * @deprecated Use the constructor taking in a ChangeLogLoader moving forward
+   */
   public ChangeService(String changeLogsBasePackage) {
     this(changeLogsBasePackage, null);
   }
 
+  /**
+   * Constructs a ChangeService which uses the parameters passed in.
+   * 
+   * @param changeLogsBasePackage
+   * @param environment
+   * @deprecated Use the constructor taking in a ChangeLogLoader moving forward
+   */
   public ChangeService(String changeLogsBasePackage, Environment environment) {
-    this.changeLogsBasePackage = changeLogsBasePackage;
+    this.changeLogLoader = new SpringProfileChangeLogLoader(changeLogsBasePackage, environment);
+  }
 
-    if (environment != null && environment.getActiveProfiles() != null && environment.getActiveProfiles().length> 0) {
-      this.activeProfiles = asList(environment.getActiveProfiles());
-    } else {
-      this.activeProfiles = asList(DEFAULT_PROFILE);
-    }
+  public ChangeService(ChangeLogLoader changeLogLoader) {
+    this.changeLogLoader = changeLogLoader;
   }
 
   public List<Class<?>> fetchChangeLogs(){
-    Reflections reflections = new Reflections(changeLogsBasePackage);
-    Set<Class<?>> changeLogs = reflections.getTypesAnnotatedWith(ChangeLog.class); // TODO remove dependency, do own method
-    List<Class<?>> filteredChangeLogs = (List<Class<?>>) filterByActiveProfiles(changeLogs);
-
-    Collections.sort(filteredChangeLogs, new ChangeLogComparator());
-
-    return filteredChangeLogs;
+    return this.changeLogLoader.fetchChangeLogClasses();
   }
 
   public List<Method> fetchChangeSets(final Class<?> type) throws MongobeeChangeSetException {
-    final List<Method> changeSets = filterChangeSetAnnotation(asList(type.getDeclaredMethods()));
-    final List<Method> filteredChangeSets = (List<Method>) filterByActiveProfiles(changeSets);
+    return this.changeLogLoader.fetchChangeSets(type);
+  }
 
-    Collections.sort(filteredChangeSets, new ChangeSetComparator());
-
-    return filteredChangeSets;
+  public Object fetchChangeLogInstance(final Class<?> changeLogClass) throws MongobeeException {
+    return this.changeLogLoader.fetchChangeLogInstance(changeLogClass);
   }
 
   public boolean isRunAlwaysChangeSet(Method changesetMethod){
@@ -88,51 +80,4 @@ public class ChangeService {
       return null;
     }
   }
-
-  private boolean matchesActiveSpringProfile(AnnotatedElement element) {
-    if (!ClassUtils.isPresent("org.springframework.context.annotation.Profile", null)) {
-      return true;
-    }
-    if (!element.isAnnotationPresent(Profile.class)) {
-      return true; // no-profiled changeset always matches
-    }
-    List<String> profiles = asList(element.getAnnotation(Profile.class).value());
-    for (String profile : profiles) {
-      if (profile != null && profile.length() > 0 && profile.charAt(0) == '!') {
-        if (!activeProfiles.contains(profile.substring(1))) {
-          return true;
-        }
-      } else if (activeProfiles.contains(profile)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private List<?> filterByActiveProfiles(Collection<? extends AnnotatedElement> annotated) {
-    List<AnnotatedElement> filtered = new ArrayList<>();
-    for (AnnotatedElement element : annotated) {
-      if (matchesActiveSpringProfile(element)){
-        filtered.add( element);
-      }
-    }
-    return filtered;
-  }
-
-  private List<Method> filterChangeSetAnnotation(List<Method> allMethods) throws MongobeeChangeSetException {
-    final Set<String> changeSetIds = new HashSet<>();
-    final List<Method> changesetMethods = new ArrayList<>();
-    for (final Method method : allMethods) {
-      if (method.isAnnotationPresent(ChangeSet.class)) {
-        String id = method.getAnnotation(ChangeSet.class).id();
-        if (changeSetIds.contains(id)) {
-          throw new MongobeeChangeSetException(String.format("Duplicated changeset id found: '%s'", id));
-        }
-        changeSetIds.add(id);
-        changesetMethods.add(method);
-      }
-    }
-    return changesetMethods;
-  }
-
 }

--- a/src/main/java/com/github/mongobee/utils/SpringProfileChangeLogLoader.java
+++ b/src/main/java/com/github/mongobee/utils/SpringProfileChangeLogLoader.java
@@ -1,0 +1,77 @@
+package com.github.mongobee.utils;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.env.Environment;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+
+public class SpringProfileChangeLogLoader extends ChangeLogLoader {
+
+  private static final String DEFAULT_PROFILE = "default";
+  private final List<String> activeProfiles;
+
+  public SpringProfileChangeLogLoader(String changeLogsBasePackage, Environment environment) {
+    super(changeLogsBasePackage);
+    if (environment != null && environment.getActiveProfiles() != null && environment.getActiveProfiles().length > 0) {
+      this.activeProfiles = asList(environment.getActiveProfiles());
+    } else {
+      this.activeProfiles = asList(DEFAULT_PROFILE);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  /**
+   * Filters change log classes by the active profile
+   */
+  public List<Class<?>> filterChangeLogClasses(Set<Class<?>> changeLogClassSet) {
+    return (List<Class<?>>) filterByActiveProfiles(changeLogClassSet);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  /**
+   * Filters change set methods by the active profile
+   */
+  public List<Method> filterChangeSetMethods(List<Method> methods) {
+    return (List<Method>) filterByActiveProfiles(methods);
+  }
+
+  private List<?> filterByActiveProfiles(Collection<? extends AnnotatedElement> annotated) {
+    List<AnnotatedElement> filtered = new ArrayList<>();
+    for (AnnotatedElement element : annotated) {
+      if (matchesActiveSpringProfile(element)) {
+        filtered.add(element);
+      }
+    }
+    return filtered;
+  }
+
+  private boolean matchesActiveSpringProfile(AnnotatedElement element) {
+    if (!ClassUtils.isPresent("org.springframework.context.annotation.Profile", null)) {
+      return true;
+    }
+    if (!element.isAnnotationPresent(Profile.class)) {
+      return true; // no-profiled changeset always matches
+    }
+    List<String> profiles = asList(element.getAnnotation(Profile.class).value());
+    for (String profile : profiles) {
+      if (profile != null && profile.length() > 0 && profile.charAt(0) == '!') {
+        if (!activeProfiles.contains(profile.substring(1))) {
+          return true;
+        }
+      } else if (activeProfiles.contains(profile)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+}

--- a/src/test/java/com/github/mongobee/utils/ChangeLogLoaderTest.java
+++ b/src/test/java/com/github/mongobee/utils/ChangeLogLoaderTest.java
@@ -1,0 +1,62 @@
+package com.github.mongobee.utils;
+
+import com.github.mongobee.exception.MongobeeChangeSetException;
+import com.github.mongobee.test.changelogs.*;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static junit.framework.Assert.assertTrue;
+
+/**
+ * @author lstolowski
+ * @since 27/07/2014
+ */
+public class ChangeLogLoaderTest {
+
+  @Test
+  public void shouldFindChangeLogClasses(){
+    // given
+    String scanPackage = MongobeeTestResource.class.getPackage().getName();
+    ChangeLogLoader changeLogLoader = new ChangeLogLoader(scanPackage);
+    // when
+    List<Class<?>> foundClasses = changeLogLoader.fetchChangeLogClasses();
+    // then
+    assertTrue(foundClasses != null && foundClasses.size() > 0);
+  }
+  
+  @Test
+  public void shouldFindChangeSetMethods() throws MongobeeChangeSetException {
+    // given
+    String scanPackage = MongobeeTestResource.class.getPackage().getName();
+    ChangeLogLoader changeLogLoader = new ChangeLogLoader(scanPackage);
+
+    // when
+    List<Method> foundMethods = changeLogLoader.fetchChangeSets(MongobeeTestResource.class);
+    
+    // then
+    assertTrue(foundMethods != null && foundMethods.size() == 5);
+  }
+
+  @Test
+  public void shouldFindAnotherChangeSetMethods() throws MongobeeChangeSetException {
+    // given
+    String scanPackage = MongobeeTestResource.class.getPackage().getName();
+    ChangeLogLoader changeLogLoader = new ChangeLogLoader(scanPackage);
+
+    // when
+    List<Method> foundMethods = changeLogLoader.fetchChangeSets(AnotherMongobeeTestResource.class);
+
+    // then
+    assertTrue(foundMethods != null && foundMethods.size() == 6);
+  }
+
+  @Test(expected = MongobeeChangeSetException.class)
+  public void shouldFailOnDuplicatedChangeSets() throws MongobeeChangeSetException {
+    String scanPackage = ChangeLogWithDuplicate.class.getPackage().getName();
+    ChangeLogLoader changeLogLoader = new ChangeLogLoader(scanPackage);
+    changeLogLoader.fetchChangeSets(ChangeLogWithDuplicate.class);
+  }
+
+}


### PR DESCRIPTION
Intention is to allow custom filtering and instantiation of change logs and change sets. For an app I work on, we believed change log objects would be much easier to use if we could inject our existing DAOs and services into them with the DI framework we use (Guice). This is one way to solve that problem while keeping things simple and allowing for backwards compatibility.