### PR TITLE
#57: Flexible changelogs location

### DIFF
--- a/src/main/java/com/github/mongobee/Mongobee.java
+++ b/src/main/java/com/github/mongobee/Mongobee.java
@@ -1,8 +1,23 @@
 package com.github.mongobee;
 
-import com.github.mongobee.changeset.ChangeEntry;
+import static com.mongodb.ServerAddress.defaultHost;
+import static com.mongodb.ServerAddress.defaultPort;
+import static org.springframework.util.StringUtils.hasText;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+
 import com.github.mongobee.changeset.ChangeLogsProvider;
 import com.github.mongobee.changeset.ScanPackageChangeLogsProvider;
+import org.jongo.Jongo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.core.env.Environment;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+import com.github.mongobee.changeset.ChangeEntry;
 import com.github.mongobee.dao.ChangeEntryDao;
 import com.github.mongobee.exception.MongobeeChangeSetException;
 import com.github.mongobee.exception.MongobeeConfigurationException;
@@ -13,20 +28,6 @@ import com.mongodb.DB;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientURI;
 import com.mongodb.client.MongoDatabase;
-import org.jongo.Jongo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.InitializingBean;
-import org.springframework.core.env.Environment;
-import org.springframework.data.mongodb.core.MongoTemplate;
-
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.List;
-
-import static com.mongodb.ServerAddress.defaultHost;
-import static com.mongodb.ServerAddress.defaultPort;
-import static org.springframework.util.StringUtils.hasText;
 
 /**
  * Mongobee runner

--- a/src/main/java/com/github/mongobee/changeset/ChangeLogsProvider.java
+++ b/src/main/java/com/github/mongobee/changeset/ChangeLogsProvider.java
@@ -1,0 +1,7 @@
+package com.github.mongobee.changeset;
+
+import java.util.Set;
+
+public interface ChangeLogsProvider {
+  Set<Class<?>> load();
+}

--- a/src/main/java/com/github/mongobee/changeset/ScanPackageChangeLogsProvider.java
+++ b/src/main/java/com/github/mongobee/changeset/ScanPackageChangeLogsProvider.java
@@ -1,0 +1,19 @@
+package com.github.mongobee.changeset;
+
+import org.reflections.Reflections;
+
+import java.util.Set;
+
+public class ScanPackageChangeLogsProvider implements ChangeLogsProvider {
+  private final String changeLogsBasePackage;
+
+  public ScanPackageChangeLogsProvider(String changeLogsBasePackage) {
+    this.changeLogsBasePackage = changeLogsBasePackage;
+  }
+
+  @Override
+  public Set<Class<?>> load() {
+    Reflections reflections = new Reflections(changeLogsBasePackage);
+    return reflections.getTypesAnnotatedWith(ChangeLog.class); // TODO remove dependency, do own method
+  }
+}

--- a/src/main/java/com/github/mongobee/utils/ChangeService.java
+++ b/src/main/java/com/github/mongobee/utils/ChangeService.java
@@ -1,22 +1,15 @@
 package com.github.mongobee.utils;
 
 import com.github.mongobee.changeset.ChangeEntry;
-import com.github.mongobee.changeset.ChangeLog;
+import com.github.mongobee.changeset.ChangeLogsProvider;
 import com.github.mongobee.changeset.ChangeSet;
 import com.github.mongobee.exception.MongobeeChangeSetException;
-import org.reflections.Reflections;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.env.Environment;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import static java.util.Arrays.asList;
 
@@ -29,15 +22,15 @@ import static java.util.Arrays.asList;
 public class ChangeService {
   private static final String DEFAULT_PROFILE = "default";
 
-  private final String changeLogsBasePackage;
+  private final ChangeLogsProvider changeLogsProvider;
   private final List<String> activeProfiles;
 
-  public ChangeService(String changeLogsBasePackage) {
-    this(changeLogsBasePackage, null);
+  public ChangeService(ChangeLogsProvider changeLogsProvider) {
+    this(changeLogsProvider, null);
   }
 
-  public ChangeService(String changeLogsBasePackage, Environment environment) {
-    this.changeLogsBasePackage = changeLogsBasePackage;
+  public ChangeService(ChangeLogsProvider changeLogsProvider, Environment environment) {
+    this.changeLogsProvider = changeLogsProvider;
 
     if (environment != null && environment.getActiveProfiles() != null && environment.getActiveProfiles().length> 0) {
       this.activeProfiles = asList(environment.getActiveProfiles());
@@ -47,8 +40,7 @@ public class ChangeService {
   }
 
   public List<Class<?>> fetchChangeLogs(){
-    Reflections reflections = new Reflections(changeLogsBasePackage);
-    Set<Class<?>> changeLogs = reflections.getTypesAnnotatedWith(ChangeLog.class); // TODO remove dependency, do own method
+    Set<Class<?>> changeLogs = changeLogsProvider.load();
     List<Class<?>> filteredChangeLogs = (List<Class<?>>) filterByActiveProfiles(changeLogs);
 
     Collections.sort(filteredChangeLogs, new ChangeLogComparator());

--- a/src/main/java/com/github/mongobee/utils/ChangeService.java
+++ b/src/main/java/com/github/mongobee/utils/ChangeService.java
@@ -9,7 +9,13 @@ import org.springframework.core.env.Environment;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import static java.util.Arrays.asList;
 

--- a/src/test/java/com/github/mongobee/changeset/ScanPackageChangeLogsProviderTest.java
+++ b/src/test/java/com/github/mongobee/changeset/ScanPackageChangeLogsProviderTest.java
@@ -1,0 +1,23 @@
+package com.github.mongobee.changeset;
+
+import com.github.mongobee.test.changelogs.MongobeeTestResource;
+import org.junit.Test;
+
+import java.util.Set;
+
+import static junit.framework.Assert.assertTrue;
+
+public class ScanPackageChangeLogsProviderTest {
+
+  @Test
+  public void shouldFindChangeLogClasses() {
+    // given
+    String scanPackage = MongobeeTestResource.class.getPackage().getName();
+    ScanPackageChangeLogsProvider provider = new ScanPackageChangeLogsProvider(scanPackage);
+    // when
+    Set<Class<?>> foundClasses = provider.load();
+    // then
+    assertTrue(foundClasses != null && foundClasses.size() > 0);
+  }
+
+}

--- a/src/test/java/com/github/mongobee/utils/ChangeServiceTest.java
+++ b/src/test/java/com/github/mongobee/utils/ChangeServiceTest.java
@@ -1,6 +1,7 @@
 package com.github.mongobee.utils;
 
 import com.github.mongobee.changeset.ChangeEntry;
+import com.github.mongobee.changeset.ScanPackageChangeLogsProvider;
 import com.github.mongobee.exception.MongobeeChangeSetException;
 import com.github.mongobee.test.changelogs.*;
 import junit.framework.Assert;
@@ -19,21 +20,10 @@ import static junit.framework.Assert.assertTrue;
 public class ChangeServiceTest {
 
   @Test
-  public void shouldFindChangeLogClasses(){
-    // given
-    String scanPackage = MongobeeTestResource.class.getPackage().getName();
-    ChangeService service = new ChangeService(scanPackage);
-    // when
-    List<Class<?>> foundClasses = service.fetchChangeLogs();
-    // then
-    assertTrue(foundClasses != null && foundClasses.size() > 0);
-  }
-  
-  @Test
   public void shouldFindChangeSetMethods() throws MongobeeChangeSetException {
     // given
     String scanPackage = MongobeeTestResource.class.getPackage().getName();
-    ChangeService service = new ChangeService(scanPackage);
+    ChangeService service = new ChangeService(new ScanPackageChangeLogsProvider(scanPackage));
 
     // when
     List<Method> foundMethods = service.fetchChangeSets(MongobeeTestResource.class);
@@ -46,7 +36,7 @@ public class ChangeServiceTest {
   public void shouldFindAnotherChangeSetMethods() throws MongobeeChangeSetException {
     // given
     String scanPackage = MongobeeTestResource.class.getPackage().getName();
-    ChangeService service = new ChangeService(scanPackage);
+    ChangeService service = new ChangeService(new ScanPackageChangeLogsProvider(scanPackage));
 
     // when
     List<Method> foundMethods = service.fetchChangeSets(AnotherMongobeeTestResource.class);
@@ -60,7 +50,7 @@ public class ChangeServiceTest {
   public void shouldFindIsRunAlwaysMethod() throws MongobeeChangeSetException {
     // given
     String scanPackage = MongobeeTestResource.class.getPackage().getName();
-    ChangeService service = new ChangeService(scanPackage);
+    ChangeService service = new ChangeService(new ScanPackageChangeLogsProvider(scanPackage));
 
     // when
     List<Method> foundMethods = service.fetchChangeSets(AnotherMongobeeTestResource.class);
@@ -79,7 +69,7 @@ public class ChangeServiceTest {
     
     // given
     String scanPackage = MongobeeTestResource.class.getPackage().getName();
-    ChangeService service = new ChangeService(scanPackage);
+    ChangeService service = new ChangeService(new ScanPackageChangeLogsProvider(scanPackage));
     List<Method> foundMethods = service.fetchChangeSets(MongobeeTestResource.class);
 
     for (Method foundMethod : foundMethods) {
@@ -99,7 +89,7 @@ public class ChangeServiceTest {
   @Test(expected = MongobeeChangeSetException.class)
   public void shouldFailOnDuplicatedChangeSets() throws MongobeeChangeSetException {
     String scanPackage = ChangeLogWithDuplicate.class.getPackage().getName();
-    ChangeService service = new ChangeService(scanPackage);
+    ChangeService service = new ChangeService(new ScanPackageChangeLogsProvider(scanPackage));
     service.fetchChangeSets(ChangeLogWithDuplicate.class);
   }
 


### PR DESCRIPTION
Switched to using a provider for the changelog classes. The changes are backward compatible (assuming `ChangeService` is not part of the public API).