### PR TITLE
Update mongo java driver version to 3.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <groupId>com.github.mongobee</groupId>
     <artifactId>mongobee</artifactId>
-    <version>0.14-SNAPSHOT</version>
+    <version>0.15-SNAPSHOT</version>
 
     <licenses>
         <license>
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongo-java-driver</artifactId>
-            <version>3.3.0</version>
+            <version>3.11.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/src/main/java/com/github/mongobee/dao/ChangeEntryIndexDao.java
+++ b/src/main/java/com/github/mongobee/dao/ChangeEntryIndexDao.java
@@ -1,17 +1,21 @@
 package com.github.mongobee.dao;
 
-import org.bson.Document;
-
 import com.github.mongobee.changeset.ChangeEntry;
+import com.mongodb.client.ListIndexesIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.IndexOptions;
+import org.bson.Document;
 
 /**
  * @author lstolowski
  * @since 10.12.14
+ *
+ * @author Amit Sadafule
+ * @since 19.08.149
  */
 public class ChangeEntryIndexDao {
+
 
   private String changelogCollectionName;
 	  
@@ -28,13 +32,17 @@ public class ChangeEntryIndexDao {
   }
 
   public Document findRequiredChangeAndAuthorIndex(MongoDatabase db) {
-    MongoCollection<Document> indexes = db.getCollection("system.indexes");
-    Document index = indexes.find(new Document()
-        .append("ns", db.getName() + "." + changelogCollectionName)
-        .append("key", new Document().append(ChangeEntry.KEY_CHANGEID, 1).append(ChangeEntry.KEY_AUTHOR, 1))
-    ).first();
-
-    return index;
+    ListIndexesIterable<Document> indexes = db.getCollection(changelogCollectionName).listIndexes();
+    if(indexes == null) {
+      return null;
+    }
+    for(Document indexDefinition : indexes) {
+      Document key = indexDefinition.get("key", Document.class);
+      if(key.get(ChangeEntry.KEY_CHANGEID) != null && key.get(ChangeEntry.KEY_AUTHOR) != null) {
+        return indexDefinition;
+      }
+    }
+    return null;
   }
 
   public boolean isUnique(Document index) {


### PR DESCRIPTION
1. Updated mongo java driver version to 3.11
2. Used mongo java driver's list index method to get dbchangelog db index info instead of system.indexes(deprecated collection)